### PR TITLE
Update Spire Server Config and Version

### DIFF
--- a/docker/spire-server/Dockerfile
+++ b/docker/spire-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/spiffe-io/spire-server:unstable
+FROM gcr.io/spiffe-io/spire-server:0.10.1
 
 # Override spire configurations
 COPY conf/spire-server.conf /opt/spire/conf/server/server.conf

--- a/docker/spire-server/conf/spire-server.conf
+++ b/docker/spire-server/conf/spire-server.conf
@@ -8,7 +8,7 @@ server {
 	log_level = "DEBUG"
 	log_file = "/opt/spire/server.log"
 	upstream_bundle = false
-	svid_ttl = "1h"
+	default_svid_ttl = "1h"
 	ca_subject = {
 		Country = ["US"],
 		Organization = ["SPIFFE"],


### PR DESCRIPTION
Spire Server has renamed the `svid_ttl` param to `default_svid_ttl`, preventing the `spire-server` container from launching sucessfully.  This PR updates that config and pins the Spire Server version to the latest stable release (`0.10.1`).